### PR TITLE
Allow `create` to accept a function returning a Provider

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+var _ = require("lodash");
 var Web3 = require("web3");
 
 module.exports = {
@@ -34,7 +35,9 @@ module.exports = {
   create: function(options) {
     var provider;
 
-    if (options.provider) {
+    if (options.provider && _.isFunction(options.provider)) {
+      provider = options.provider();
+    } else if (options.provider) {
       provider = options.provider;
     } else {
       provider = new Web3.providers.HttpProvider("http://" + options.host + ":" + options.port);

--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ module.exports = {
   create: function(options) {
     var provider;
 
-    if (options.provider && _.isFunction(options.provider)) {
+    if (options.provider && typeof options.provider == "function") {
       provider = options.provider();
     } else if (options.provider) {
       provider = options.provider;

--- a/package.json
+++ b/package.json
@@ -25,5 +25,9 @@
   "dependencies": {
     "lodash": "^4.5.1",
     "web3": "^0.18.0"
+  },
+  "devDependencies": {
+    "ethereumjs-testrpc": "^3.0.5",
+    "mocha": "^3.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "homepage": "https://github.com/trufflesuite/truffle-provider#readme",
   "dependencies": {
+    "lodash": "^4.5.1",
     "web3": "^0.18.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   },
   "homepage": "https://github.com/trufflesuite/truffle-provider#readme",
   "dependencies": {
-    "lodash": "^4.5.1",
     "web3": "^0.18.0"
   },
   "devDependencies": {

--- a/test/create.js
+++ b/test/create.js
@@ -4,23 +4,37 @@ var TestRPC = require("ethereumjs-testrpc");
 var Provider = require("../index");
 
 describe("Provider", function() {
-  var HttpProvider;
+  var server;
+  var port = 12345;
 
-  beforeEach("mock HttpProvider", function() {
-    HttpProvider = Web3.providers.HttpProvider;
-    Web3.providers.HttpProvider = TestRPC.provider;
+  before("Initialize TestRPC server", function(done) {
+    server = TestRPC.server({});
+    server.listen(port, function (err) {
+      assert.ifError(err);
+      done();
+    });
   });
 
-  afterEach("unmock HttpProvider", function() {
-    Web3.providers.HttpProvider = HttpProvider;
+  after("Shutdown TestRPC", function(done) {
+    server.close(done);
   });
 
   it("accepts host and port", function(done) {
-    var provider = Provider.create({host: "0.0.0.0", port: "8545"});
+    var provider = Provider.create({host: "0.0.0.0", port: port});
     assert(provider);
 
     Provider.test_connection(provider, function(error, coinbase) {
       assert.ifError(error);
+      done();
+    });
+  });
+
+  it("fails to connect to the wrong port", function(done) {
+    var provider = Provider.create({host: "0.0.0.0", port: "54321"});
+    assert(provider);
+
+    Provider.test_connection(provider, function(error, coinbase) {
+      assert(error);
       done();
     });
   });

--- a/test/create.js
+++ b/test/create.js
@@ -1,0 +1,50 @@
+var assert = require("assert");
+var Web3 = require("web3");
+var TestRPC = require("ethereumjs-testrpc");
+var Provider = require("../index");
+
+describe("Provider", function() {
+  var HttpProvider;
+
+  beforeEach("mock HttpProvider", function() {
+    HttpProvider = Web3.providers.HttpProvider;
+    Web3.providers.HttpProvider = TestRPC.provider;
+  });
+
+  afterEach("unmock HttpProvider", function() {
+    Web3.providers.HttpProvider = HttpProvider;
+  });
+
+  it("accepts host and port", function(done) {
+    var provider = Provider.create({host: "0.0.0.0", port: "8545"});
+    assert(provider);
+
+    Provider.test_connection(provider, function(error, coinbase) {
+      assert.ifError(error);
+      done();
+    });
+  });
+
+  it("accepts a provider instance", function(done) {
+    var provider = Provider.create({provider: new TestRPC.provider()});
+    assert(provider);
+
+    Provider.test_connection(provider, function(error, coinbase) {
+      assert.ifError(error);
+      done();
+    });
+  });
+
+  it("accepts a function that returns a provider instance", function(done) {
+    var provider = Provider.create({
+      provider: function() { return new TestRPC.provider()}
+    });
+
+    assert(provider);
+
+    Provider.test_connection(provider, function(error, coinbase) {
+      assert.ifError(error);
+      done();
+    });
+  });
+});


### PR DESCRIPTION
Ref: trufflesuite/truffle#348

In order to prevent all specified network providers from being instantiated / from making constant HTTP requests all the time. Instead, support wrapping provider instances in a function block to resolve instances only required for selected `--network`