### PR TITLE
Added support of HTTPS schema in config

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ module.exports = {
     } else if (options.provider) {
       provider = options.provider;
     } else {
-      provider = new Web3.providers.HttpProvider("http://" + options.host + ":" + options.port);
+      provider = new Web3.providers.HttpProvider((options.schema || "http") + "://" + options.host + ":" + options.port);
     }
 
     return this.wrap(provider, options);

--- a/test/create.js
+++ b/test/create.js
@@ -19,8 +19,8 @@ describe("Provider", function() {
     server.close(done);
   });
 
-  it("accepts host and port", function(done) {
-    var provider = Provider.create({host: "0.0.0.0", port: port});
+  it("accepts schema, host and port", function(done) {
+    var provider = Provider.create({schema: 'http', host: "0.0.0.0", port: port});
     assert(provider);
 
     Provider.test_connection(provider, function(error, coinbase) {


### PR DESCRIPTION
Added new option to network config: `schema`. If not provided while using provider connection string building from `host` and `port` then defaulted to `http`.