### PR TITLE
Update for web3 1.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,8 @@ module.exports = {
       provider = options.provider();
     } else if (options.provider) {
       provider = options.provider;
+    } else if (options.websockets) {
+      provider = new Web3.providers.WebsocketProvider("ws://" + options.host + ":" + options.port);
     } else {
       provider = new Web3.providers.HttpProvider("http://" + options.host + ":" + options.port);
     }

--- a/index.js
+++ b/index.js
@@ -23,13 +23,14 @@ module.exports = {
 
   test_connection: function(provider, callback) {
     var web3 = new Web3();
-    web3.setProvider(provider);
-    web3.eth.getCoinbase(function(error, coinbase) {
-      if (error != null) {
-        error = new Error("Could not connect to your RPC client. Please check your RPC configuration.");
-      }
+    var fail = new Error("Could not connect to your RPC client. Please check your RPC configuration.");
 
-      callback(error, coinbase)
-    });
+    web3.setProvider(provider);
+
+    web3
+      .eth
+      .getCoinbase()
+      .then(coinbase => callback(null, coinbase))
+      .catch(e => callback(fail, null));
   }
 };

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://github.com/trufflesuite/truffle-provider#readme",
   "dependencies": {
     "truffle-error": "^0.0.2",
-    "web3": "^0.20.1"
+    "web3": "1.0.0-beta.33"
   },
   "devDependencies": {
     "ganache-cli": "6.1.0-beta.4",

--- a/wrapper.js
+++ b/wrapper.js
@@ -23,11 +23,9 @@ module.exports = {
     var postHook = this.postHook(options);
 
     var originalSend = provider.send.bind(provider);
-    var originalSendAsync = provider.sendAsync.bind(provider);
 
-    /* overwrite methods */
+    /* overwrite method */
     provider.send = this.send(originalSend, preHook, postHook);
-    provider.sendAsync = this.sendAsync(originalSendAsync, preHook, postHook);
 
     /* mark as wrapped */
     provider._alreadyWrapped = true;
@@ -90,42 +88,11 @@ module.exports = {
    *
    * Return the wrapped function matching the original function's signature.
    */
-
-  // wrap a `provider.send` function with behavior hooks
-  // returns a function(payload) to replace `provider.send`
   send: function(originalSend, preHook, postHook) {
-    return function(payload) {
-      var result = null;
-      var error = null;
-
-      payload = preHook(payload);
-
-      try {
-        result = originalSend(payload);
-      } catch (e) {
-        error = e;
-      }
-
-      var modified = postHook(payload, error, result);
-      payload = modified[0];
-      error = modified[1];
-      result = modified[2];
-
-      if (error != null) {
-        throw error;
-      }
-
-      return result;
-    }
-  },
-
-  // wrap a `provider.sendAsync` function with behavior hooks
-  // returns a function(payload, callback) to replace `provider.sendAsync`
-  sendAsync: function(originalSendAsync, preHook, postHook) {
     return function(payload, callback) {
       payload = preHook(payload);
 
-      originalSendAsync(payload, function(error, result) {
+      originalSend(payload, function(error, result) {
         var modified = postHook(payload, error, result);
         payload = modified[0];
         error = modified[1];


### PR DESCRIPTION
+ Consolidates `sendAsync` into `send` following web3 1.0, which is all async and has opted for `send` as the method name.
+ Bumps web3 to 1.0.0-beta.33